### PR TITLE
Rename ~/.auth to ~/.profitbricks-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ You will be notified with the following message if you have provided incorrect c
 >Invalid user name or password. Please try again!
 ```
 
-After successful authentication you will no longer need to provide credentials unless you want to change them. They are stored as a BASE64 encoded string in a '.auth' file in your home directory.
+After successful authentication you will no longer need to provide credentials unless you want to change them. They are stored as a BASE64 encoded string in a '.profitbricks-auth' file in your home directory.
 
 # How To's:
 

--- a/helpers.js
+++ b/helpers.js
@@ -10,7 +10,7 @@ exports.setJson = setJson
 exports.setForce = setForce
 exports.force = force
 
-var authFile = (process.env.HOME || process.env.USERPROFILE) + '/.auth'
+var authFile = (process.env.HOME || process.env.USERPROFILE) + '/.profitbricks-auth'
 
 var isJson = false
 var force = false


### PR DESCRIPTION
Pull request for #53.

`~/.auth` is a very generic file name. At the very least, there should be a prefix such as `profitbricks-`, which is implemented in this PR.